### PR TITLE
CSS Padding on index.html page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/style.css
+++ b/style.css
@@ -62,9 +62,18 @@
   }
   
   /*Tribute info styles*/
+  .body {
+	padding: 10px;
+  }
   
   .naruto {
 	float: left;
+  }
+  .tribute,
+  .one,
+  .two, 
+  .tribute2 {
+	padding-right: 30px;
   }
   .tribute {
 	font-size: 1.7vw;


### PR DESCRIPTION
Added padding to body to keep words from touching the edge of the screen.  Added extra padding to .tribute, .one, .two, and .tribute 2 to keep from touching the edge of the page and achieve a balanced look.